### PR TITLE
Add m1 support

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,6 +29,28 @@ jobs:
         command: build
         args: --release
 
+    - if: runner.os == 'MacOS'
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: aarch64-apple-darwin
+
+    - if: runner.os == 'MacOS'
+      uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: --release --target=aarch64-apple-darwin
+
+    - name: Create universal lib for macOS
+      if: runner.os == 'MacOS'
+      run: |
+        mkdir -p target/tmp
+        mv target/release/libdeno_installer.dylib target/tmp/libdeno_installer.dylib
+
+        lipo -create -output target/release/libdeno_installer.dylib \
+          target/tmp/libdeno_installer.dylib \
+          target/aarch64-apple-darwin/release/libdeno_installer.dylib
+
     - name: Release MacOS lib
       if: runner.os == 'MacOS'
       uses: svenstaro/upload-release-action@v2


### PR DESCRIPTION
Release universal lib for macOS (aarch64 + x86_64 both)

If you think there is a much simpler approach on workflow, feel free to comment. (I'm not good at writing workflow :q)
Also you can see the working example on: https://github.com/hyp3rflow/deno_installer/releases/tag/0.0.3-test