### PR TITLE
Fix 'create_installer' obsolete encoding operation

### DIFF
--- a/bindings/bindings.ts
+++ b/bindings/bindings.ts
@@ -8,7 +8,7 @@ function decode(v: Uint8Array): string {
   return new TextDecoder().decode(v)
 }
 function readPointer(v: any): Uint8Array {
-  const ptr = new Deno.UnsafePointerView(v as Deno.UnsafePointer)
+  const ptr = new Deno.UnsafePointerView(v)
   const lengthBe = new Uint8Array(4)
   const view = new DataView(lengthBe.buffer)
   ptr.copyInto(lengthBe, 0)

--- a/bindings/bindings.ts
+++ b/bindings/bindings.ts
@@ -55,8 +55,9 @@ export type BundleSettingsInstaller = {
   long_description: string | undefined | null
 }
 export function create_installer(a0: InstallerSettings) {
-  const a0_buf = encode(JSON.stringify(a0))
-  let rawResult = _lib.symbols.create_installer(a0_buf, a0_buf.byteLength)
-  const result = rawResult
+  const a0_buf = encode(JSON.stringify(a0));
+  const a0_ptr = Deno.UnsafePointer.of(a0_buf);
+  let rawResult = _lib.symbols.create_installer(a0_ptr, a0_buf.byteLength);
+  const result = rawResult;
   return result
 }


### PR DESCRIPTION
New Deno versions requires using of the `Uint32` / `BigInt`, instead `Uint8Array`, when exporting module function. 
The original way currently resusts in error and exception when trying to `createInstaller()`, when using latest and probably some previous Deno releases.

```ts 
  error: Uncaught (in promise) TypeError: Invalid FFI pointer type, expected null, integer or BigInt
  let rawResult = _lib.symbols.create_installer(a0_buf, a0_buf.byteLength)
                               ^
    at create_installer (file:///D:/Projects/Personal/deno_installer/bindings/bindings.ts:59:32)
    at Installer.createInstaller (file:///D:/Projects/Personal/deno_installer/mod.ts:18:11)
    at async file:///D:/Projects/Personal/deno_installer/examples/oak/build.ts:24:1
```

I've make a small fix in ths PR, which result is that the `Installer` is  working well again, by using `Uint32` in the `bindings.ts` `create_installer` method export. 